### PR TITLE
Hide DuckDB schemas in metadata to avoid three-part identifiers

### DIFF
--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -412,25 +412,32 @@
          (for [{:keys [table_schema table_name]}
                (jdbc/query {:connection (clone-raw-connection conn)}
                            [get_tables_query])]
-           {:name table_name :schema table_schema}))))}))
+           {:name           table_name
+            :schema         nil
+            :duckdb/schema table_schema}))))}))
 
 (defmethod driver/describe-table :duckdb
-  [driver database {table_name :name, schema :schema}]
+  [driver database {table_name :name, schema :schema :as table}]
   (let [database_file (get (get database :details) :database_file)
         database_file (first (database-file-path-split database_file))  ;; remove additional options in connection string
+        duckdb-schema (or (:duckdb/schema table) schema)
+        schema-filter (if duckdb-schema
+                        (format " and table_schema = '%s'" duckdb-schema)
+                        "")
         get_columns_query (str
                            (format
-                            "select * from information_schema.columns where table_name = '%s' and table_schema = '%s'"
-                            table_name schema)
+                            "select * from information_schema.columns where table_name = '%s'"
+                            table_name)
+                           schema-filter
                                   ;; Additionally filter by db_name if connecting to MotherDuck, since
                                   ;; multiple databases can be attached and information about the
                                   ;; non-target database will be present in information_schema.
                            (if (is_motherduck database_file)
                              (let [db_name_without_md (motherduck_db_name database_file)]
-                               (format "and table_catalog = '%s' " db_name_without_md))
+                               (format " and table_catalog = '%s' " db_name_without_md))
                              ""))]
     {:name   table_name
-     :schema schema
+     :schema nil
      :fields
      (sql-jdbc.execute/do-with-connection-with-options
       driver database nil


### PR DESCRIPTION
## Summary
- hide DuckDB schema names when describing tables so Metabase only uses two-part identifiers
- retain the schema internally during sync to continue fetching column metadata safely

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d45577e2d88331b159fca036a9574d