### PR TITLE
Handle unknown DuckDB field base types

### DIFF
--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -240,7 +240,10 @@
 
 (defmethod sql-jdbc.sync/database-type->base-type :duckdb
   [_ field-type]
-  (database-type->base-type field-type))
+  (let [base-type (when field-type (database-type->base-type field-type))]
+    (when (nil? base-type)
+      (log/warnf "Unknown DuckDB field type %s, defaulting base type to :type/*" field-type))
+    (or base-type :type/*)))
 
 (defn- local-time-to-time [^LocalTime lt]
   (Time. (.getLong lt ChronoField/MILLI_OF_DAY)))


### PR DESCRIPTION
## Summary
- avoid inserting NULL base types when DuckDB reports a column type the driver does not recognize
- log a warning and default such fields to :type/* so metadata sync can proceed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d563efd24883318a520d02db17f0a3